### PR TITLE
refactor: remove use of extern crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,6 @@ dependencies = [
  "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt-derive 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -714,6 +713,9 @@ dependencies = [
 name = "serde"
 version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde_derive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,7 @@ travis-ci = { repository = "anglerud/hootie" }
 [dependencies]
 anyhow = "1.0.32"
 reqwest = { version = "0.10.7", features = ["blocking", "json"] }
-serde = "1.0.114"
-serde_derive = "1.0.114"
+serde = { version = "1.0.114", features = ["derive"] }
 structopt = "0.3.16"
 structopt-derive = "0.4.9"
 termion = "1.5.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,10 @@
-extern crate reqwest;
-#[macro_use]
-extern crate serde_derive;
-extern crate structopt;
-extern crate structopt_derive;
-extern crate termion;
-
 use std::fmt;
 use std::io::{stdout, Write};
 use std::{thread, time};
 
 use anyhow::Result;
 use structopt::StructOpt;
+use serde::Deserialize;
 use termion::color;
 use termion::cursor;
 use termion::screen::AlternateScreen;


### PR DESCRIPTION
No longer needed in 2018 edition. Required a slight change to
use of serde's derives.