### PR TITLE
fix: clear screen before redraw

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,6 @@ use termion::cursor;
 use termion::screen::AlternateScreen;
 
 // TODO: Use env_logger (or similar) instead of println!
-// TODO: clear screen before first loop
 
 /// Configuration struct
 ///
@@ -93,7 +92,7 @@ fn get_alerts(opt: &Opt) -> Result<Alerts> {
 fn display(alerts: Alerts) -> std::io::Result<()> {
     let mut screen = AlternateScreen::from(stdout());
 
-    write!(screen, "{}Alerta alerts\n\n", cursor::Goto(1, 1))?;
+    write!(screen, "{}{}Alerta alerts\n\n", termion::clear::All, cursor::Goto(1, 1))?;
 
     if alerts.alerts.is_empty() {
         write!(


### PR DESCRIPTION
This makes the first display not coexist with what was on the
screen before.